### PR TITLE
Replace the broken link with a working one

### DIFF
--- a/src/Experience.jsx
+++ b/src/Experience.jsx
@@ -10,7 +10,7 @@ export default function Experience()
     const [ isOpen, setIsOpen ] = useState(false)
     const HtmlRef = useRef()
 
-    const macbook = useGLTF('https://vazxmixjsiawhamofees.supabase.co/storage/v1/object/public/models/macbook/model.gltf')
+    const macbook = useGLTF('https://threejs-journey.com/resources/models/macbook_model.gltf')
     const camera = useThree((state) => state.camera)
     // macbook.scene.rotation.set(0, 3, 0)
     // macbook initial setup


### PR DESCRIPTION
It turned out that pmnd link wasn't working, so I had to use an alternative made by three.js team.